### PR TITLE
Update to v0.3.20 from cloudyr drat repo

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,6 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1
+channels:
+  targets:
+    - [conda-forge, dev]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '0.3.12' %}
+{% set version = '0.3.20' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -10,13 +10,14 @@ package:
 source:
   fn: aws.s3_{{ version }}.tar.gz
   url:
+    - https://github.com/cloudyr/cloudyr.github.io/raw/master/drat/src/contrib/aws.s3_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/aws.s3_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/aws.s3/aws.s3_{{ version }}.tar.gz
-  sha256: 348fbbd976b5bcfbb60024864b5859fa3fce6071d5204667ff158296614cd1f9
+  sha256: 03f46497015709c317f6390d2035a4f0a5a6076cae9466f45f0ba6362250e766
 
 build:
   merge_build_host: True  # [win]
-  number: 1
+  number: 0
 
   rpaths:
     - lib/R/lib/
@@ -30,6 +31,7 @@ requirements:
     - r-base
     - r-aws.signature >=0.3.7
     - r-base64enc
+    - r-curl
     - r-digest
     - r-httr
     - r-xml2 >1.0.0
@@ -38,6 +40,7 @@ requirements:
     - r-base
     - r-aws.signature >=0.3.7
     - r-base64enc
+    - r-curl
     - r-digest
     - r-httr
     - r-xml2 >1.0.0


### PR DESCRIPTION
The latest cran version (0.3.12) is pretty outdated. Lots of bugs were
fixed since then in newer package versions as documented in the closed
github issues. The newer package versions are available via the cloudyr
drat repo as described in the readme of the package itself.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
